### PR TITLE
[Robot Framework] Add new tables for *Task* and *Tasks*

### DIFF
--- a/pygments/lexers/robotframework.py
+++ b/pygments/lexers/robotframework.py
@@ -123,6 +123,7 @@ class RowTokenizer:
                         'metadata': settings,
                         'variables': variables, 'variable': variables,
                         'testcases': testcases, 'testcase': testcases,
+                        'tasks': testcases, 'task': testcases,
                         'keywords': keywords, 'keyword': keywords,
                         'userkeywords': keywords, 'userkeyword': keywords}
 


### PR DESCRIPTION
Since Robot Framework 3.1 (January 2019), new tables *Tasks* and *Task* are available. The syntax highlighting is the same as for the already existing testcases.

See release notes:  https://github.com/robotframework/robotframework/blob/master/doc/releasenotes/rf-3.1.rst#terminology-configuration-to-support-robotic-process-automation-rpa 

This pull requests adds new 2 new ables: *Tasks* and *Task*.

I do not know how to test it, but the fix should be simple.